### PR TITLE
Override transferOwnership in API3 token

### DIFF
--- a/packages/api3-token/contracts/Api3Token.sol
+++ b/packages/api3-token/contracts/Api3Token.sol
@@ -72,7 +72,7 @@ contract Api3Token is ERC20, Ownable, IApi3Token {
     }
 
     /// @notice Overrides Ownable transferOwnership function. Ensures old owner
-    /// is removed from minting permissions and new owner is set.
+    /// is removed from minting permissions.
     function transferOwnership(address newOwner)
         public
         override
@@ -80,8 +80,6 @@ contract Api3Token is ERC20, Ownable, IApi3Token {
     {
             // Remove old owner as a minter
             updateMinterStatus(owner(), false);
-            // Add new owner as a minter
-            updateMinterStatus(newOwner, true);
             // Transfer ownership
             super.transferOwnership(newOwner);
     }

--- a/packages/api3-token/contracts/Api3Token.sol
+++ b/packages/api3-token/contracts/Api3Token.sol
@@ -36,7 +36,7 @@ contract Api3Token is ERC20, Ownable, IApi3Token {
         address minterAddress,
         bool minterStatus
         )
-        external
+        public
         override
         onlyOwner
     {
@@ -69,5 +69,20 @@ contract Api3Token is ERC20, Ownable, IApi3Token {
         returns(bool minterStatus)
     {
         minterStatus = isMinter[minterAddress];
+    }
+
+    /// @notice Overrides Ownable transferOwnership function. Ensures old owner
+    /// is removed from minting permissions and new owner is set.
+    function transferOwnership(address newOwner)
+        public
+        override
+        onlyOwner
+    {
+            // Remove old owner as a minter
+            updateMinterStatus(owner(), false);
+            // Add new owner as a minter
+            updateMinterStatus(newOwner, true);
+            // Transfer ownership
+            super.transferOwnership(newOwner);
     }
 }

--- a/packages/api3-token/contracts/Api3Token.sol
+++ b/packages/api3-token/contracts/Api3Token.sol
@@ -75,7 +75,7 @@ contract Api3Token is ERC20, Ownable, IApi3Token {
     /// @param newOwner the new owner of the contract
     /// is removed from minting permissions.
     function transferOwnership(address newOwner)
-        external
+        public
         override
         onlyOwner
     {

--- a/packages/api3-token/contracts/Api3Token.sol
+++ b/packages/api3-token/contracts/Api3Token.sol
@@ -72,6 +72,7 @@ contract Api3Token is ERC20, Ownable, IApi3Token {
     }
 
     /// @notice Overrides Ownable transferOwnership function. Ensures old owner
+    /// @param newOwner the new owner of the contract
     /// is removed from minting permissions.
     function transferOwnership(address newOwner)
         external

--- a/packages/api3-token/contracts/Api3Token.sol
+++ b/packages/api3-token/contracts/Api3Token.sol
@@ -74,7 +74,7 @@ contract Api3Token is ERC20, Ownable, IApi3Token {
     /// @notice Overrides Ownable transferOwnership function. Ensures old owner
     /// is removed from minting permissions.
     function transferOwnership(address newOwner)
-        public
+        external
         override
         onlyOwner
     {

--- a/packages/api3-token/test/Api3Token.sol.js
+++ b/packages/api3-token/test/Api3Token.sol.js
@@ -120,9 +120,7 @@ describe("transfer ownership", function () {
           .transferOwnership(roles.randomPerson._address)
       )
         .to.emit(api3Token, "MinterStatusUpdated")
-        .withArgs(roles.dao._address, false)
-        .to.emit(api3Token, "MinterStatusUpdated")
-        .withArgs(roles.randomPerson._address, true);
+        .withArgs(roles.dao._address, false);
     });
   });
 

--- a/packages/api3-token/test/Api3Token.sol.js
+++ b/packages/api3-token/test/Api3Token.sol.js
@@ -110,3 +110,27 @@ describe("mint", function () {
     });
   });
 });
+
+describe("transfer ownership", function () {
+  context("If the caller is the owner", async function () {
+    it("removes old owner minting permission, sets new owner minting permission", async function () {
+      await expect(
+        api3Token
+          .connect(roles.dao)
+          .transferOwnership(roles.randomPerson._address)
+      )
+        .to.emit(api3Token, "MinterStatusUpdated")
+        .withArgs(roles.dao._address, false)
+        .to.emit(api3Token, "MinterStatusUpdated")
+        .withArgs(roles.randomPerson._address, true);
+    });
+  });
+
+  context("If the caller is not the owner", async function () {
+    it("reverts", async function () {
+      await expect(
+        api3Token.transferOwnership(roles.randomPerson._address)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+  });
+});


### PR DESCRIPTION
Updates the transferOwnership function to ensure when owners are removed, their minting permissions are also removed. Also automatically gives the new owner minting permissions as this saves them from sending a transaction to set this.